### PR TITLE
feat(admin): implement soft delete and admin event management

### DIFF
--- a/packages/webapp/src/app/admin/deleted-events/page.tsx
+++ b/packages/webapp/src/app/admin/deleted-events/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import type { Event } from "@/types";
+
+
+export default function DeletedEventsPage() {
+  const [deletedEvents, setDeletedEvents] = useState<Event[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    async function fetchDeletedEvents() {
+        setLoading(true);
+        setError("");
+        const { data, error } = await supabase
+            .from("events")
+            .select("*")
+            .not("deleted_at", "is", null)
+            .is("permanently_deleted_at", null);
+        if (error) {
+            setError("Failed to load deleted events: " + error.message);
+            setDeletedEvents([]);
+        } else {
+            setDeletedEvents(data || []);
+        }
+        setLoading(false);
+    }
+    fetchDeletedEvents();
+  }, []);
+// .eq("permanently_deleted_at", null); up there
+  const handleRestore = async (id: string) => {
+    setError("");
+    const { error } = await supabase
+        .from('events')
+        .update({ deleted_at: null })
+        .eq('id', id);
+    if (error) {
+        setError("Failed to restore event: " + error.message);
+        return;
+    }
+    setDeletedEvents(deletedEvents.filter(e => e.id !== id));
+  };
+
+  const handlePermanentDelete = async (id: string) => {
+    if (!confirm("Permanently delete this event? This cannot be undone.")) return;
+    setError("");
+    const { error } = await supabase
+        .from("events")
+        .update({ permanently_deleted_at: new Date().toISOString() })
+        .eq('id', id);  
+    if (error) {
+        setError("Failed to permanently delete event: " + error.message);
+        return;
+    }
+    setDeletedEvents(deletedEvents.filter(e => e.id !== id));
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-3xl mx-auto py-8">
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">Deleted Events (Admin)</h1>
+        {deletedEvents.length === 0 ? (
+          <p>No deleted events.</p>
+        ) : (
+          <ul className="space-y-4">
+            {deletedEvents.map(event => {
+              // Calculate days since deleted
+              const deletedAt = event.deleted_at ? new Date(event.deleted_at) : null;
+              const now = new Date();
+              const daysSinceDeleted = deletedAt ? Math.floor((now.getTime() - deletedAt.getTime()) / (1000 * 60 * 60 * 24)) : 0;
+              const daysLeft = 30 - daysSinceDeleted;
+
+              return (
+                <li key={event.id} className="bg-white shadow p-4 rounded-lg flex justify-between items-center">
+                  <div>
+                    <div className="font-semibold text-gray-900">{event.title}</div>
+                    <div className="text-sm text-gray-700">
+                      Deleted {daysSinceDeleted} day{daysSinceDeleted !== 1 ? "s" : ""} ago
+                      {daysLeft > 0 ? (
+                        <span className="ml-2 text-xs text-gray-500">
+                          ({daysLeft} day{daysLeft !== 1 ? "s" : ""} until safe to delete)
+                        </span>
+                      ) : (
+                        <span className="ml-2 text-xs text-green-600 font-semibold">
+                          Safe to permanently delete from website.
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleRestore(event.id)}
+                      className="bg-green-600 text-white px-3 py-1 rounded hover:bg-green-700"
+                    >
+                      Restore
+                    </button>
+                    <button
+                      onClick={() => handlePermanentDelete(event.id)}
+                      className="bg-red-600 text-white px-3 py-1 rounded hover:bg-red-700"
+                      disabled={daysLeft > 0}
+                      title={daysLeft > 0 ? "Can only delete after 30 days" : ""}
+                    >
+                      Permanently Delete
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/webapp/src/app/events/[id]/page.tsx
+++ b/packages/webapp/src/app/events/[id]/page.tsx
@@ -8,22 +8,7 @@ import { notFound } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import VibeCheckModal from '@/components/VibeCheckModal'; // Import the component
-
-interface Event {
-  id: string;
-  title: string;
-  original_text?: string;
-  date?: string;
-  start_time?: string;
-  end_time?: string;
-  location?: string;
-  category: string;
-  audience?: string;
-  post_url?: string;
-  image_url?: string;
-  status: string;
-  created_at: string;
-}
+import type { Event } from "@/types";
 
 // Helper functions
 function formatDate(dateStr: string) {
@@ -108,6 +93,24 @@ export default function EventDetailPage() {
       }
     } catch (error) {
       console.log('Share cancelled or failed:', error);
+    }
+  };
+
+  const handleSoftDelete = async () => {
+    if (!event) {
+      alert("No event selected.");
+      return;
+    }
+
+    if (!confirm("Are you sure you want to delete this event? You can restore it within 30 days.")) return;
+    const { error } = await supabase
+      .from('events')
+      .update({ deleted_at: new Date().toISOString() })
+      .eq('id', event.id);
+    if (error) {
+      alert("Failed to delete event: " + error.message);
+    } else {
+      window.location.reload();
     }
   };
 
@@ -301,12 +304,20 @@ export default function EventDetailPage() {
                       Share Event
                     </button>
                     {userType === "admin" && (
-                      <Link
-                        href={`/admin/edit-event/${event.id}`}
-                        className="inline-block bg-yellow-500 hover:bg-yellow-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 mb-4"
-                      >
-                        Edit Event
-                      </Link>
+                      <div className="flex justify-center gap-4 mt-8">
+                        <Link
+                          href={`/admin/edit-event/${event.id}`}
+                          className="w-40 text-center bg-yellow-500 hover:bg-yellow-600 text-white font-medium py-3 px-6 rounded-lg transition-colors duration-200 flex items-center justify-center"
+                        >
+                          Edit Event
+                        </Link>
+                        <button
+                          onClick={handleSoftDelete}
+                          className="w-40 text-center bg-red-600 hover:bg-red-700 text-white font-medium py-3 px-6 rounded-lg flex items-center justify-center transition-colors duration-200"
+                        >
+                          Delete Event
+                        </button>
+                      </div>
                     )}
                   </div>
                 </div>

--- a/packages/webapp/src/components/EventsWithFilters.tsx
+++ b/packages/webapp/src/components/EventsWithFilters.tsx
@@ -4,22 +4,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import EventCard from './EventCard';
 import FilterNavigation from './FilterNavigation';
-
-interface Event {
-  id: string;
-  title: string;
-  original_text?: string;
-  date?: string;
-  start_time?: string;
-  end_time?: string;
-  location?: string;
-  category: string;
-  audience?: string;
-  post_url?: string;
-  image_url?: string;
-  status: string;
-  created_at: string;
-}
+import type { Event } from "@/types";
 
 interface EventsWithFiltersProps {
   allEvents: Event[];
@@ -49,16 +34,16 @@ export default function EventsWithFilters({ allEvents }: EventsWithFiltersProps)
 
   // FIXED: Filter events based on category - corrected logic
   const filteredEvents = useMemo(() => {
-    console.log('Filtering events:', { selectedCategory, totalEvents: allEvents.length });
-    
+    let events = allEvents;
+
+    // Exclude soft-deleted events
+    events = events.filter(event => !event.deleted_at);
+
     if (selectedCategory === 'All Events') {
-      console.log('Showing all events:', allEvents.length);
-      return allEvents;
+      return events;
     }
-    
-    const filtered = allEvents.filter(event => event.category === selectedCategory);
-    console.log(`Filtered ${selectedCategory} events:`, filtered.length);
-    return filtered;
+
+    return events.filter(event => event.category === selectedCategory);
   }, [allEvents, selectedCategory]);
 
   // Handle category change

--- a/packages/webapp/src/components/NavigationBar.tsx
+++ b/packages/webapp/src/components/NavigationBar.tsx
@@ -162,6 +162,13 @@ export default function NavigationBar() {
                         >
                           Create Event
                         </Link>
+                        <Link
+                          href="/admin/deleted-events"
+                          onClick={() => setIsProfileOpen(false)}
+                          className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md"
+                        >
+                          Manage Deleted Events
+                        </Link>
                         <hr className="my-2" />
                         <button 
                           onClick={handleSignOut}

--- a/packages/webapp/src/types/index.ts
+++ b/packages/webapp/src/types/index.ts
@@ -5,6 +5,7 @@
 export interface Event {
   id: string;
   title: string;
+  deleted_at?: string;
   original_text?: string;
   date?: string;
   start_time?: string;


### PR DESCRIPTION
- Added soft delete functionality for events (sets deleted_at timestamp)
- Updated event filtering to exclude soft-deleted events from general audience
- Added 'Manage Deleted Events' link to NavigationBar for admins
- Improved deleted-events admin page: restore and permanently delete options, 30-day countdown, and UI consistency
- Updated Event type to support